### PR TITLE
Fixed type-hinting for ContainerInterface

### DIFF
--- a/src/Authorization.php
+++ b/src/Authorization.php
@@ -7,6 +7,7 @@ use Chadicus\Slim\OAuth2\Http\ResponseBridge;
 use Chadicus\Psr\Middleware\MiddlewareInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Message\ResponseInterface;
+use Interop\Container\ContainerInterface;
 use OAuth2;
 
 /**


### PR DESCRIPTION
IDE was expecting class `Chadicus\Slim\OAuth2\Middleware\ContainerInterface` instead of `Interop\Container\ContainerInterface` due to missing use statement.