### PR TITLE
Allow PSR-11 containers in 3.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "chadicus/slim-oauth2-http": "^3.1",
         "chadicus/psr-middleware": "^1.0",
         "psr/http-message": "^1.0",
-        "container-interop/container-interop": "^1.1"
+        "container-interop/container-interop": "^1.2"
     },
     "require-dev": {
         "chadicus/coding-standard": "^1.3",

--- a/src/Authorization.php
+++ b/src/Authorization.php
@@ -7,7 +7,7 @@ use Chadicus\Slim\OAuth2\Http\ResponseBridge;
 use Chadicus\Psr\Middleware\MiddlewareInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Message\ResponseInterface;
-use Interop\Container\ContainerInterface;
+use Psr\Container\ContainerInterface;
 use OAuth2;
 
 /**
@@ -54,9 +54,9 @@ class Authorization implements MiddlewareInterface
     public function __construct(OAuth2\Server $server, $container, array $scopes = [])
     {
         $this->server = $server;
-        if (!is_a($container, '\\ArrayAccess') && !is_a($container, '\\Interop\\Container\\ContainerInterface')) {
+        if (!is_a($container, '\\ArrayAccess') && !is_a($container, '\\Psr\\Container\\ContainerInterface')) {
             throw new \InvalidArgumentException(
-                '$container does not implement \\ArrayAccess or \\Interop\\Container\\ContainerInterface'
+                '$container does not implement \\ArrayAccess or \\Psr\\Container\\ContainerInterface'
             );
         }
 

--- a/tests/AuthorizationTest.php
+++ b/tests/AuthorizationTest.php
@@ -466,7 +466,7 @@ final class AuthorizationTest extends \PHPUnit_Framework_TestCase
      * @test
      * @covers ::__construct
      * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage $container does not implement \ArrayAccess or \Interop\Container\ContainerInterface
+     * @expectedExceptionMessage $container does not implement \ArrayAccess or \Psr\Container\ContainerInterface
      *
      * @return void
      */


### PR DESCRIPTION
I'm a fan of the change to attributes in the 4.x branch, but in the meantime, it'd be nice if the 3.x branch supported PSR-11 containers. I updated my project to use PHP-DI 6 and this library broke because of the container type check. Containers that implement container-interop will still work since `Interop\Container\ContainerInterface` extends from `Psr\Container\ContainerInterface` now.