### PR TITLE
Reduce restrictions for container

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,6 @@
         "chadicus/psr-middleware": "^1.0",
         "chadicus/slim-oauth2-http": "^3.1",
         "container-interop/container-interop": "^1.1",
-        "psr/container": "^1.0",
         "psr/http-message": "^1.0"
     },
     "require-dev": {

--- a/src/Authorization.php
+++ b/src/Authorization.php
@@ -5,10 +5,8 @@ use ArrayAccess;
 use Chadicus\Slim\OAuth2\Http\RequestBridge;
 use Chadicus\Slim\OAuth2\Http\ResponseBridge;
 use Chadicus\Psr\Middleware\MiddlewareInterface;
-use Interop\Container\ContainerInterface as InteropContainerInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Message\ResponseInterface;
-use Psr\Container\ContainerInterface;
 use OAuth2;
 
 /**
@@ -33,22 +31,21 @@ class Authorization implements MiddlewareInterface
     /**
      * Container for token.
      *
-     * @var ArrayAccess|ContainerInterface
+     * @var mixed
      */
     private $container;
 
     /**
      * Create a new instance of the Authroization middleware.
      *
-     * @param OAuth2\Server                  $server    The configured OAuth2 server.
-     * @param ArrayAccess|ContainerInterface $container A container object in which to store the token from the
-     *                                                  request.
-     * @param array                          $scopes    Scopes required for authorization. $scopes can be given as an
-     *                                                  array of arrays. OR logic will use with each grouping.
-     *                                                  Example:
-     *                                                  Given ['superUser', ['basicUser', 'aPermission']], the request
-     *                                                  will be verified if the request token has 'superUser' scope
-     *                                                  OR 'basicUser' and 'aPermission' as its scope.
+     * @param OAuth2\Server $server    The configured OAuth2 server.
+     * @param mixed         $container A container object in which to store the token from the request.
+     * @param array         $scopes    Scopes required for authorization. $scopes can be given as an
+     *                                 array of arrays. OR logic will use with each grouping.
+     *                                 Example:
+     *                                 Given ['superUser', ['basicUser', 'aPermission']], the request
+     *                                 will be verified if the request token has 'superUser' scope
+     *                                 OR 'basicUser' and 'aPermission' as its scope.
      *
      * @throws \InvalidArgumentException Thrown if $container is not an instance of ArrayAccess or ContainerInterface.
      */
@@ -149,21 +146,10 @@ class Authorization implements MiddlewareInterface
             return $container;
         }
 
-        if (is_a($container, ContainerInterface::class)) {
+        if (method_exists($container, 'set')) {
             return $container;
         }
 
-        if (is_a($container, InteropContainerInterface::class)) {
-            return $container;
-        }
-
-        throw new \InvalidArgumentException(
-            sprintf(
-                '$container does not implement %s, %s, or %s',
-                ArrayAccess::class,
-                ContainerInterface::class,
-                InteropContainerInterface::class
-            )
-        );
+        throw new \InvalidArgumentException("\$container does not implement ArrayAccess or contain a 'set' method");
     }
 }

--- a/tests/AuthorizationTest.php
+++ b/tests/AuthorizationTest.php
@@ -466,7 +466,7 @@ final class AuthorizationTest extends \PHPUnit_Framework_TestCase
      * @test
      * @covers ::__construct
      * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage $container does not implement ArrayAccess, Psr\Container\ContainerInterface
+     * @expectedExceptionMessage $container does not implement ArrayAccess or contain a 'set' method
      *
      * @return void
      */
@@ -474,6 +474,23 @@ final class AuthorizationTest extends \PHPUnit_Framework_TestCase
     {
         $oauth2ServerMock = $this->getMockBuilder('\\OAuth2\\Server')->disableOriginalConstructor()->getMock();
         new Authorization($oauth2ServerMock, new \StdClass());
+    }
+
+    /**
+     * Verify middleware cannot be constructed with a pure PSR-11 container.
+     *
+     * @test
+     * @covers ::__construct
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage $container does not implement ArrayAccess or contain a 'set' method
+     *
+     * @return void
+     */
+    public function constructWithPSR11Container()
+    {
+        $container = $this->getMockBuilder('\\Psr\\Container\\ContainerInterface')->getMock();
+        $oauth2ServerMock = $this->getMockBuilder('\\OAuth2\\Server')->disableOriginalConstructor()->getMock();
+        new Authorization($oauth2ServerMock, $container);
     }
 
     /**


### PR DESCRIPTION
#### What does this PR do?
This pull request allows the container to be either an `ArrayAccess` object or any object that implements a `set` method.
#### Checklist
- [ ] Pull request contains a clear definition of changes
- [ ] Tests (either unit, integration, or acceptance) written and passing
- [ ] Relevant documentation produced and/or updated
